### PR TITLE
remove empty file with asian characters in filename (causes problems …

### DIFF
--- a/app/src/main/jni/harfbuzz-0.9.41/到 src 的链接
+++ b/app/src/main/jni/harfbuzz-0.9.41/到 src 的链接
@@ -1,1 +1,0 @@
-/home/junling/harfbuzz-0.9.41/src


### PR DESCRIPTION
…eg with command line tools such as install scripts that expect ascii characters in filenames)